### PR TITLE
Added product "status" to classify each product

### DIFF
--- a/src/models/product.model.js
+++ b/src/models/product.model.js
@@ -1,6 +1,14 @@
 const {model, Schema} = require('mongoose')
 
 const productSchema = new Schema({
+    status:{
+      type: String,
+      required: true,
+      enum: {
+        values: ['sell', 'rent', 'sellAndRent'],
+        message: 'Invalid product status, please select one'
+      }
+    },
     nameProduct:{
       type: String,
       required: true,


### PR DESCRIPTION
SNX-51 includes:
New "**status**" attribute added to _Product schema_:
**Status** options:
- buy
- rent
- buyAndRent (both options)

Status was added in order to classify each product by **user** desires (**user**: owner of the product, who is publishing the product on soundX). 

For example, some users desire only to publish a product _for sale_, while other only want to offer it _for rent_... and maybe some other user wants to offer the same product for sale or rent.